### PR TITLE
feat: add unix and HTTPS support

### DIFF
--- a/.resolvrrc
+++ b/.resolvrrc
@@ -2,3 +2,5 @@ nginx-bin-path: 'C:/nginx'
 nginx-config-file: 'C:/nginx/conf/nginx.conf'
 root-app-name: 'jake-test'
 polling-frequency: 5
+key-path: ''
+cert-path: ''

--- a/app.js
+++ b/app.js
@@ -4,8 +4,14 @@ const fastifyAutoLoad = require('fastify-autoload')
 const fastifyCookie = require('fastify-cookie')
 const cosmiconfig = require('cosmiconfig')
 const explorer = cosmiconfig('resolvr')
+const fs = require('fs')
 
-module.exports = (fastify, opts, next) => {
+const getConfig = async () => {
+  const { config } = await explorer.search()
+  return config
+}
+
+const mainPlugin = async (fastify, opts, next) => {
   fastify.register(fastifyAutoLoad, {
     dir: path.join(__dirname, 'services')
   })
@@ -14,12 +20,27 @@ module.exports = (fastify, opts, next) => {
     if (err) throw err
   })
 
-  explorer.search().then(async ({ config }) => {
-    const nginxConfigWorker = await createNginxConfigWorker(config)
-    nginxConfigWorker.listen(stdout => {
-      console.log(stdout)
-    })
+  const config = await getConfig()
+  const nginxConfigWorker = await createNginxConfigWorker(config)
+  nginxConfigWorker.listen(stdout => {
+    console.log(stdout)
   })
 
   next()
 }
+
+const start = async () => {
+  const {
+    'key-path': keyPath,
+    'cert-path': certPath
+  } = await getConfig()
+
+  const options = keyPath
+    ? { https: { key: fs.readFileSync(keyPath), cert: fs.readFileSync(certPath) } }
+    : {}
+  const fastify = require('fastify')(options)
+
+  fastify.register(mainPlugin)
+}
+
+start()

--- a/nginxConfig/nginxConfigTask.js
+++ b/nginxConfig/nginxConfigTask.js
@@ -2,7 +2,7 @@ const path = require('path')
 const pm2 = require('pm2')
 const argv = require('minimist')(process.argv.slice(2))
 const { NginxConfFile } = require('nginx-conf')
-const { exec } = require('child_process')
+const execa = require('execa')
 let latestConfigBody
 
 const getNginxAbConfig = (rootApp, appList) => {
@@ -72,8 +72,9 @@ const updateNginxConfig = async nginxConfig => {
 
   await amendNginxConfig(nginxConfig, abConfig)
 
-  const { bin } = argv
-  exec(`cd ${bin} && start /MIN /B nginx -s reload && exit`)
+  const { bin: cwd } = argv
+  const { stdout } = execa('nginx', ['-s', 'reload'], { cwd })
+  console.log(stdout)
 
   const { frequency } = argv
   const pollingFrequency = frequency * 1000

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "resolvr",
+  "name": "@jakewhelan/resolvr",
   "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,
@@ -1596,17 +1596,39 @@
       "dev": true
     },
     "execa": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+      "version": "1.0.0",
+      "resolved": "https://www.artifactrepository.citigroup.net:443/artifactory/api/npm/npm/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha1-xiNqW7TfbW8V6I5/AXeYIWdJ3dg=",
       "requires": {
-        "cross-spawn": "^5.0.1",
-        "get-stream": "^3.0.0",
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
         "is-stream": "^1.1.0",
         "npm-run-path": "^2.0.0",
         "p-finally": "^1.0.0",
         "signal-exit": "^3.0.0",
         "strip-eof": "^1.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://www.artifactrepository.citigroup.net:443/artifactory/api/npm/npm/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://www.artifactrepository.citigroup.net:443/artifactory/api/npm/npm/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha1-wbJVV189wh1Zv8ec09K0axw6VLU=",
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        }
       }
     },
     "expand-brackets": {
@@ -2129,7 +2151,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2147,11 +2170,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2164,15 +2189,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2275,7 +2303,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2285,6 +2314,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2297,17 +2327,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2324,6 +2357,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2396,7 +2430,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2406,6 +2441,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2481,7 +2517,8 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2511,6 +2548,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2528,6 +2566,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2566,11 +2605,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -3775,6 +3816,11 @@
       "resolved": "https://registry.npmjs.org/nginx-conf/-/nginx-conf-1.4.0.tgz",
       "integrity": "sha1-tb0ghwRVp5iL6ARNhtJriCjGd3s="
     },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://www.artifactrepository.citigroup.net:443/artifactory/api/npm/npm/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha1-ozeKdpbOfSI+iPybdkvX7xCJ42Y="
+    },
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -3797,7 +3843,7 @@
     },
     "npm-run-path": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "resolved": "https://www.artifactrepository.citigroup.net:443/artifactory/api/npm/npm/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "requires": {
         "path-key": "^2.0.0"
@@ -3863,6 +3909,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -5045,7 +5092,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "loose-envify": {
           "version": "1.3.1",
@@ -6590,7 +6638,7 @@
     },
     "p-finally": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "resolved": "https://www.artifactrepository.citigroup.net:443/artifactory/api/npm/npm/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-limit": {
@@ -6689,7 +6737,7 @@
     },
     "path-key": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "resolved": "https://www.artifactrepository.citigroup.net:443/artifactory/api/npm/npm/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
     "path-parse": {
@@ -7749,7 +7797,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://www.artifactrepository.citigroup.net:443/artifactory/api/npm/npm/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-json-comments": {
@@ -7898,6 +7946,22 @@
       "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
       "requires": {
         "execa": "^0.7.0"
+      },
+      "dependencies": {
+        "execa": {
+          "version": "0.7.0",
+          "resolved": "https://www.artifactrepository.citigroup.net:443/artifactory/api/npm/npm/execa/-/execa-0.7.0.tgz",
+          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+          "requires": {
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        }
       }
     },
     "text-table": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@rauschma/stringio": "^1.4.0",
     "cosmiconfig": "^5.0.5",
     "esm": "^3.0.66",
+    "execa": "^1.0.0",
     "fastify": "^1.6.0",
     "fastify-autoload": "^0.4.0",
     "fastify-cli": "^0.16.3",

--- a/services/ab.js
+++ b/services/ab.js
@@ -1,7 +1,11 @@
 const getResolvrAbTestCookies = cookies => Object.keys(cookies).filter(key => key.includes('resolvr-ab-'))
 
 module.exports = (fastify, opts, next) => {
-  fastify.get('/ab/set/:abTestName', function ({ cookies, params: { abTestName } }, reply) {
+  fastify.get('/', (request, reply) => {
+    reply.send({ works: true })
+  })
+
+  fastify.get('/ab/set/:abTestName', ({ cookies, params: { abTestName } }, reply) => {
     if (cookies) {
       const resolvrAbTestCookies = getResolvrAbTestCookies(cookies)
       for (const cookie of resolvrAbTestCookies) {


### PR DESCRIPTION
- Replace use of `child_process.exec` with `execa` for improved platform support.
- Add support to config for HTTPS when running `fastify`, if no keys provided it will run as HTTP.